### PR TITLE
Add npm-debug.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env/
 node_modules/
+npm-debug.log
 .DS_Store
 assets/js/react/bundle.js


### PR DESCRIPTION
This removes `npm-debug.log` from version control.
