### PR TITLE
Remove unused `npm test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "scripts": {
     "reactbuild": "watchify -t 6to5ify assets/js/react/src/entry.js -o assets/js/react/bundle.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"
   },
   "author": "",


### PR DESCRIPTION
Running `npm test` will just throw an error—this removes that.
